### PR TITLE
fixes window.cordova.require not a function on capacitor.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 // add support for cordova-plugin-file
-const moduleMapper = typeof window !== 'undefined' && window.cordova && window.cordova.require('cordova/modulemapper');
+const moduleMapper = typeof window !== 'undefined' && window.cordova && window.cordova.require && window.cordova.require('cordova/modulemapper');
 export const CustomFile = (moduleMapper && moduleMapper.getOriginalSymbol(window, 'File')) || File;
 export const CustomFileReader = (moduleMapper && moduleMapper.getOriginalSymbol(window, 'FileReader')) || FileReader;
 /**


### PR DESCRIPTION
On Ionic capacitor window.cordova is present but may not contain require function hence its throwing an error, this fixes window.cordova.require not a function on capacitor.