### PR TITLE
fix: safari canvas mem mgmt

### DIFF
--- a/lib/image-compression.js
+++ b/lib/image-compression.js
@@ -1,4 +1,4 @@
-import { canvasToFile, drawFileInCanvas, followExifOrientation, getExifOrientation, handleMaxWidthOrHeight, getNewCanvasAndCtx } from './utils'
+import { canvasToFile, drawFileInCanvas, followExifOrientation, getExifOrientation, handleMaxWidthOrHeight, getNewCanvasAndCtx, cleanupMemory } from './utils'
 
 /**
  * Compress an image file.
@@ -17,18 +17,18 @@ export default async function compress (file, options) {
   const maxSizeByte = options.maxSizeMB * 1024 * 1024
 
   // drawFileInCanvas
-  let [img, canvas] = await drawFileInCanvas(file)
+  let [img, origCanvas] = await drawFileInCanvas(file)
 
   // handleMaxWidthOrHeight
-  canvas = handleMaxWidthOrHeight(canvas, options)
+  let maxWidthOrHeightFixedCanvas = handleMaxWidthOrHeight(origCanvas, options)
 
   // exifOrientation
   options.exifOrientation = options.exifOrientation || await getExifOrientation(file)
-  canvas = followExifOrientation(canvas, options.exifOrientation)
+  let orientationFixedCanvas = followExifOrientation(maxWidthOrHeightFixedCanvas, options.exifOrientation)
 
   let quality = 1
-
-  let tempFile = await canvasToFile(canvas, file.type, file.name, file.lastModified, quality)
+  
+  let tempFile = await canvasToFile(orientationFixedCanvas, file.type, file.name, file.lastModified, quality)
   // check if we need to compress or resize
   if (tempFile.size <= maxSizeByte) {
     // no need to compress
@@ -36,10 +36,12 @@ export default async function compress (file, options) {
   }
 
   let compressedFile = tempFile
+  let newCanvas, ctx
+  let canvas = orientationFixedCanvas
   while (remainingTrials-- && compressedFile.size > maxSizeByte) {
-    const newWidth = canvas.width * 0.9
-    const newHeight = canvas.height * 0.9
-    const [newCanvas, ctx] = getNewCanvasAndCtx(newWidth, newHeight)
+    const newWidth = canvas.width * 0.9;
+    const newHeight = canvas.height * 0.9;
+    [newCanvas, ctx] = getNewCanvasAndCtx(newWidth, newHeight)
 
     ctx.drawImage(canvas, 0, 0, newWidth, newHeight)
 
@@ -47,9 +49,17 @@ export default async function compress (file, options) {
       quality *= 0.9
     }
     compressedFile = await canvasToFile(newCanvas, file.type, file.name, file.lastModified, quality)
-
+    cleanupMemory(canvas)
     canvas = newCanvas
   }
+
+  // garbage clean canvas for safari
+  // ref: https://bugs.webkit.org/show_bug.cgi?id=195325
+  cleanupMemory(canvas)
+  cleanupMemory(newCanvas)
+  cleanupMemory(maxWidthOrHeightFixedCanvas)
+  cleanupMemory(orientationFixedCanvas)
+  cleanupMemory(origCanvas)
 
   return compressedFile
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -198,6 +198,8 @@ export function handleMaxWidthOrHeight (canvas, options) {
       newCanvas.height = maxWidthOrHeight
     }
     ctx.drawImage(canvas, 0, 0, newCanvas.width, newCanvas.height)
+
+    cleanupMemory(canvas)
   }
 
   return newCanvas
@@ -240,6 +242,8 @@ export function followExifOrientation (canvas, exifOrientation) {
 
   ctx.drawImage(canvas, 0, 0, width, height)
 
+  cleanupMemory(canvas)
+
   return newCanvas
 }
 
@@ -262,4 +266,15 @@ export function getNewCanvasAndCtx (width, height) {
   canvas.width = width
   canvas.height = height
   return [canvas, ctx]
+}
+
+/**
+ * clear Canvas memory
+ * @param canvas
+ * @returns null
+ */
+export function cleanupMemory(canvas) {
+  canvas.width = 0;
+  canvas.height = 0;
+  canvas = null;
 }


### PR DESCRIPTION
With ref to this bug https://bugs.webkit.org/show_bug.cgi?id=195325, safari doesn't clear out canvas memory and the memory stack overflows. This PR clears the memory for all the intermediate canvas instances generated during the compression phase. 