### PR TITLE
Update interfaces & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,25 +50,25 @@ const options = {
   onProgress: Function,       // optional, a function takes one progress argument (percentage from 0 to 100) 
   useWebWorker: boolean,      // optional, use multi-thread web worker, fallback to run in main-thread (default: true)
 
-  // following options are for advanced user
+  // following options are for advanced users
   maxIteration: number,       // optional, max number of iteration to compress the image (default: 10)
   exifOrientation: number,    // optional, see https://stackoverflow.com/a/32490603/10395024
   fileType: string,           // optional, fileType override
   initialQuality: number      // optional, initial quality value between 0 and 1 (default: 1)
 }
 
-imageCompression(file: File, options): Promise<File | Blob>
+imageCompression(file: File, options): Promise<File>
 ```
 ### Helper function ###
-- for advanced user only, most user won't need to use the helper functions
+- for advanced users only, most users won't need to use the helper functions
 ```javascript
-imageCompression.getDataUrlFromFile(file: File | Blob): Promise<base64 encoded string>
+imageCompression.getDataUrlFromFile(file: File): Promise<base64 encoded string>
 imageCompression.getFilefromDataUrl(dataUrl: string, filename: string, lastModified?: number): Promise<File>
 imageCompression.loadImage(url: string): Promise<HTMLImageElement>
 imageCompression.drawImageInCanvas(img: HTMLImageElement): HTMLCanvasElement | OffscreenCanvas
-imageCompression.drawFileInCanvas(file: File| Blob): Promise<[ImageBitmap | HTMLImageElement, HTMLCanvasElement | OffscreenCanvas]>
-imageCompression.canvasToFile(canvas: HTMLCanvasElement | OffscreenCanvas, fileType: string, fileName: string, fileLastModified: number, quality?: number): Promise<File | Blob>
-imageCompression.getExifOrientation(file: File| Blob): Promise<number> // based on https://stackoverflow.com/a/32490603/10395024
+imageCompression.drawFileInCanvas(file: File): Promise<[ImageBitmap | HTMLImageElement, HTMLCanvasElement | OffscreenCanvas]>
+imageCompression.canvasToFile(canvas: HTMLCanvasElement | OffscreenCanvas, fileType: string, fileName: string, fileLastModified: number, quality?: number): Promise<File>
+imageCompression.getExifOrientation(file: File): Promise<number> // based on https://stackoverflow.com/a/32490603/10395024
 ```
 
 ## Usage ##
@@ -148,11 +148,7 @@ You can include the following script to load the Promise polyfill:
 ```
 
 ## Typescript type definitions ##
-```
-npm install --save-dev @types/browser-image-compression
-or
-yarn add --dev @types/browser-image-compression
-```
+Typescript definitions are included in the package & referenced in the `types` section of the `package.json`
 
 ## Contribution ##
 1. fork the repo and git clone it

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for browser-image-compression 1.0
 // Project: https://github.com/Donaldcwl/browser-image-compression
-// Definitions by: Donald <https://github.com/Donaldcwl>
+// Definitions by: Donald <https://github.com/Donaldcwl> & Jamie Haywood <https://github.com/jamiehaywood>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Options {
@@ -22,16 +22,16 @@ interface Options {
     initialQuality?: number;
 }
 
-declare function imageCompression(image: File | Blob, options: Options): Promise<File | Blob>;
+declare function imageCompression(image: File, options: Options): Promise<File>;
 
 declare namespace imageCompression {
-    function getDataUrlFromFile(file: File | Blob): Promise<string>;
-    function getFilefromDataUrl(dataUrl: string, filename: string, lastModified?: number): Promise<File | Blob>;
+    function getDataUrlFromFile(file: File): Promise<string>;
+    function getFilefromDataUrl(dataUrl: string, filename: string, lastModified?: number): Promise<File>;
     function loadImage(src: string): Promise<HTMLImageElement>;
     function drawImageInCanvas(img: HTMLImageElement): HTMLCanvasElement;
-    function drawFileInCanvas(file: File | Blob): Promise<[ImageBitmap | HTMLImageElement, HTMLCanvasElement]>;
-    function canvasToFile(canvas: HTMLCanvasElement, fileType: string, fileName: string, fileLastModified: number, quality?: number): Promise<File | Blob>;
-    function getExifOrientation(file: File | Blob): Promise<number>;
+    function drawFileInCanvas(file: File): Promise<[ImageBitmap | HTMLImageElement, HTMLCanvasElement]>;
+    function canvasToFile(canvas: HTMLCanvasElement, fileType: string, fileName: string, fileLastModified: number, quality?: number): Promise<File>;
+    function getExifOrientation(file: File): Promise<number>;
 }
 
 export as namespace imageCompression;


### PR DESCRIPTION
Based on the [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/API/File#Instance_methods:~:text=The%20File%20interface%20doesn't%20define%20any%20methods%2C%20but%20inherits%20methods%20from%20the%20Blob%20interface%3A) - the `File` interface inherits from the `Blob` interface and therefore the union type is unnecessary.

The primary reason for raising this PR is I was receiving type errors in my code:
```
Type 'File | Blob' is not assignable to type 'File'.
  Type 'Blob' is missing the following properties from type 'File': lastModified, name
```

This change addresses this issue. closes #83 