### PR TITLE
[bug] Fix issue with export causing this error in Angular

### DIFF
--- a/dist/browser-image-compression.d.ts
+++ b/dist/browser-image-compression.d.ts
@@ -36,4 +36,4 @@ declare namespace imageCompression {
 
 export as namespace imageCompression;
 
-export = imageCompression;
+export default imageCompression;


### PR DESCRIPTION
[bug] Fix issue with export causing this error in Angular

This module is declared with using ‘export =’, and can only be used with a default import when using the ‘allowSyntheticDefaultImports’ flag.