### PR TITLE
v2.0.0 RC

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,6 @@
 {
   "presets": [
     ["@babel/preset-env", {
-      "useBuiltIns": "usage",
-      "corejs": "3",
       "targets": {
         "browsers": ["> 5%", "ie 10-11", "not dead"]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ dist/
 build/
 
 example-express-server/uploads/
+
+stats.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * docs: add CSS animation to example html for showing main thread status
 * feature: support AbortController (abort / cancel during compression) [#101](https://github.com/Donaldcwl/browser-image-compression/issues/101)
 * feature: options.alwaysKeepResolution (default: false) - keep the resolution (width and height) during compression and reduce the quality only (note that options.maxWidthOrHeight is still applied if set) [#127](https://github.com/Donaldcwl/browser-image-compression/issues/127)
+* fixed: Main thread is blocked on Mac device for options.useWebWorker=true [#139](https://github.com/Donaldcwl/browser-image-compression/issues/139)
 * updated: dropped core-js to reduce bundle size [#138](https://github.com/Donaldcwl/browser-image-compression/issues/138)
 * updated: options.useWebWorker default set to true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0.0 (13 Apr 2022)
+* docs: add CSS animation to example html for showing main thread status
+* feature: support AbortController (abort / cancel during compression) [#101](https://github.com/Donaldcwl/browser-image-compression/issues/101)
+* feature: options.alwaysKeepResolution (default: false) - keep the resolution (width and height) during compression and reduce the quality only (note that options.maxWidthOrHeight is still applied if set) [#127](https://github.com/Donaldcwl/browser-image-compression/issues/127)
+* updated: dropped core-js to reduce bundle size [#138](https://github.com/Donaldcwl/browser-image-compression/issues/138)
+* updated: options.useWebWorker default set to true
+
 ## v1.0.17 (15 Nov 2021)
 * feature: apply white background to transparent PNG > JPG conversion if options.fileType is image/jpeg or image/jpg [#119](https://github.com/Donaldcwl/browser-image-compression/issues/119)
 * fixed: Fixed image cropped on Safari [#118](https://github.com/Donaldcwl/browser-image-compression/issues/118)

--- a/README.md
+++ b/README.md
@@ -1,53 +1,29 @@
-# Browser Image Compression #
+# Browser Image Compression
 [![npm](https://img.shields.io/npm/v/browser-image-compression.svg)](https://www.npmjs.com/package/browser-image-compression)
 [![npm](./coverage/badge.svg)](https://github.com/Donaldcwl/browser-image-compression)
 [![npm](https://img.shields.io/npm/l/browser-image-compression.svg)](https://github.com/Donaldcwl/browser-image-compression)
 
 Javascript module to be run in the web browser for image compression.
 
-## Features ##
+## Features
 - You can use this module to compress jpeg and png image by reducing **resolution** or **storage size** before uploading to application server to save bandwidth.
 - **Multi-thread** (web worker) non-blocking compression are supported through options.
-## Demo / Example ##
+
+
+## Upgrade to version 2
+Note that core-js is dropped in version 2, please read the [IE support](#ie-support) section.
+
+## Demo / Example
 open https://donaldcwl.github.io/browser-image-compression/example/basic.html
 
 or check the "[example]" folder in this repo
-## Install ##
-You can download imageCompression from the [dist folder][dist]. Alternatively, you can install it via yarn or npm
-```
-npm install browser-image-compression --save
-or
-yarn add browser-image-compression
-```
-or use a CDN like [delivrjs]:
-```
-https://cdn.jsdelivr.net/npm/browser-image-compression@1.0.17/dist/browser-image-compression.js
-or
-https://cdn.jsdelivr.net/npm/browser-image-compression@latest/dist/browser-image-compression.js
-```
 
-## How to use this module in your project? ##
-#### Use as ES module ####
 
-(can be used in framework like React, Angular, Vue etc)
-
-(work with bundler like webpack and rollup)
-```javascript
-import imageCompression from 'browser-image-compression';
-```
-
-or
-
-#### In html file ####
-```html
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/browser-image-compression@1.0.17/dist/browser-image-compression.js"></script>
-```
-
-## Usage ##
+## Usage
 ```html
 <input type="file" accept="image/*" onchange="handleImageUpload(event);">
 ```
-async await syntax:
+### async await syntax:
 ```javascript
 async function handleImageUpload(event) {
 
@@ -72,64 +48,124 @@ async function handleImageUpload(event) {
 
 }
 ```
-Promise.then().catch() syntax:
-```javascript
-function handleImageUpload(event) {
+### Promise.then().catch() syntax:
+<details>
+  <summary>Click to expand</summary>
+  
+  ```javascript
+  function handleImageUpload(event) {
 
-  var imageFile = event.target.files[0];
-  console.log('originalFile instanceof Blob', imageFile instanceof Blob); // true
-  console.log(`originalFile size ${imageFile.size / 1024 / 1024} MB`);
+    var imageFile = event.target.files[0];
+    console.log('originalFile instanceof Blob', imageFile instanceof Blob); // true
+    console.log(`originalFile size ${imageFile.size / 1024 / 1024} MB`);
 
-  var options = {
-    maxSizeMB: 1,
-    maxWidthOrHeight: 1920,
-    useWebWorker: true
+    var options = {
+      maxSizeMB: 1,
+      maxWidthOrHeight: 1920,
+      useWebWorker: true
+    }
+    imageCompression(imageFile, options)
+      .then(function (compressedFile) {
+        console.log('compressedFile instanceof Blob', compressedFile instanceof Blob); // true
+        console.log(`compressedFile size ${compressedFile.size / 1024 / 1024} MB`); // smaller than maxSizeMB
+
+        return uploadToServer(compressedFile); // write your own logic
+      })
+      .catch(function (error) {
+        console.log(error.message);
+      });
   }
-  imageCompression(imageFile, options)
-    .then(function (compressedFile) {
-      console.log('compressedFile instanceof Blob', compressedFile instanceof Blob); // true
-      console.log(`compressedFile size ${compressedFile.size / 1024 / 1024} MB`); // smaller than maxSizeMB
+  ```
+</details>
 
-      return uploadToServer(compressedFile); // write your own logic
-    })
-    .catch(function (error) {
-      console.log(error.message);
-    });
-}
+## Installing
+### Use as ES module:
+You can install it via npm or yarn
+```bash
+npm install browser-image-compression --save
+# or
+yarn add browser-image-compression
 ```
+```javascript
+import imageCompression from 'browser-image-compression';
+```
+(can be used in framework like React, Angular, Vue etc)
+
+(work with bundler like webpack and rollup)
+
+### (or) Load UMD js file:
+You can download imageCompression from the [dist folder][dist].
+
+Alternatively, you can use a CDN like [delivrjs]:
+```html
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/browser-image-compression@2.0.0/dist/browser-image-compression.js"></script>
+```
+
 
 ## Support
 If this project help you reduce time to develop, you can buy me a cup of coffee :)
 
 <a href="https://donaldcwl.github.io/donation/" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-red.png" alt="Buy Me A Coffee" height=60 width=217 ></a>
-## API ##
-### Main function ###
+
+## API
+### Main function
 ```javascript
 // you should provide one of maxSizeMB, maxWidthOrHeight in the options
 const options: Options = { 
-  maxSizeMB: number,          // (default: Number.POSITIVE_INFINITY)
-  maxWidthOrHeight: number,   // compressedFile will scale down by ratio to a point that width or height is smaller than maxWidthOrHeight (default: undefined)
-                              // but, automatically reduce the size to smaller than the maximum Canvas size supported by each browser.
-                              // Please check the Caveat part for details.
-  onProgress: Function,       // optional, a function takes one progress argument (percentage from 0 to 100) 
-  useWebWorker: boolean,      // optional, use multi-thread web worker, fallback to run in main-thread (default: true)
+  maxSizeMB: number,            // (default: Number.POSITIVE_INFINITY)
+  maxWidthOrHeight: number,     // compressedFile will scale down by ratio to a point that width or height is smaller than maxWidthOrHeight (default: undefined)
+                                // but, automatically reduce the size to smaller than the maximum Canvas size supported by each browser.
+                                // Please check the Caveat part for details.
+  onProgress: Function,         // optional, a function takes one progress argument (percentage from 0 to 100) 
+  useWebWorker: boolean,        // optional, use multi-thread web worker, fallback to run in main-thread (default: true)
+
+  signal: AbortSignal,          // options, to abort / cancel the compression
 
   // following options are for advanced users
-  maxIteration: number,       // optional, max number of iteration to compress the image (default: 10)
-  exifOrientation: number,    // optional, see https://stackoverflow.com/a/32490603/10395024
-  fileType: string,           // optional, fileType override
-  initialQuality: number      // optional, initial quality value between 0 and 1 (default: 1)
+  maxIteration: number,         // optional, max number of iteration to compress the image (default: 10)
+  exifOrientation: number,      // optional, see https://stackoverflow.com/a/32490603/10395024
+  fileType: string,             // optional, fileType override e.g., 'image/jpeg', 'image/png' (default: file.type)
+  initialQuality: number,       // optional, initial quality value between 0 and 1 (default: 1)
+  alwaysKeepResolution: boolean // optional, only reduce quality, always keep width and height (default: false)
 }
 
 imageCompression(file: File, options: Options): Promise<File>
 ```
 
-#### Caveat ####
+#### Caveat
 Each browser limits [the maximum size](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size) of a Canvas object. <br/>
 So, we resize the image to less than the maximum size that each browser restricts. <br/>
 (However, the `proportion/ratio` of the image remains.)
 
-### Helper function ###
+#### Abort / Cancel Compression
+To use this feature, please check the browser compatibility: https://caniuse.com/?search=AbortController
+```javascript
+function handleImageUpload(event) {
+
+  var imageFile = event.target.files[0];
+
+  var controller = new AbortController();
+
+  var options = {
+    // other options here
+    signal: controller.signal,
+  }
+  imageCompression(imageFile, options)
+    .then(function (compressedFile) {
+      return uploadToServer(compressedFile); // write your own logic
+    })
+    .catch(function (error) {
+      console.log(error.message); // output: I just want to stop
+    });
+  
+  // simulate abort the compression after 1.5 seconds
+  setTimeout(function () {
+    controller.abort(new Error('I just want to stop'));
+  }, 1500);
+}
+```
+
+### Helper function
 - for advanced users only, most users won't need to use the helper functions
 ```javascript
 imageCompression.getDataUrlFromFile(file: File): Promise<base64 encoded string>
@@ -141,19 +177,31 @@ imageCompression.canvasToFile(canvas: HTMLCanvasElement | OffscreenCanvas, fileT
 imageCompression.getExifOrientation(file: File): Promise<number> // based on https://stackoverflow.com/a/32490603/10395024
 ```
 
+
 ## Browsers support
 
 | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>IE / Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>iOS Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png" alt="Opera" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Opera |
 | --------- | --------- | --------- | --------- | --------- | --------- |
 | IE10, IE11, Edge| last 2 versions| last 2 versions| last 2 versions| last 2 versions| last 2 versions
 
+### IE support
+This library uses ES feature such as Promise API, globalThis. If you need to support browser that do not support new ES feature like IE. You can include the core-js polyfill in your project.
+
+You can include the following script to load the core-js polyfill:
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/3.21.1/minified.min.js"></script>
+```
+
+
 ## Remarks for compression to work in Web Worker
 The browser need to support "OffscreenCanvas" API in order to take advantage of non-blocking compression. If browser do not support "OffscreenCanvas" API, main thread is used instead. See https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas#browser_compatibility for browser compatibility of "OffscreenCanvas" API.
 
-## Typescript type definitions ##
+
+## Typescript type definitions
 Typescript definitions are included in the package & referenced in the `types` section of the `package.json`
 
-## Contribution ##
+
+## Contribution
 1. fork the repo and git clone it
 2. run `npm run watch` # it will watch code change in lib/ folder and generate js in dist/ folder
 3. add/update code in lib/ folder

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 Javascript module to be run in the web browser for image compression.
 
 ## Features
-- You can use this module to compress jpeg and png image by reducing **resolution** or **storage size** before uploading to application server to save bandwidth.
-- **Multi-thread** (web worker) non-blocking compression are supported through options.
+- You can use this module to compress jpeg and png images by reducing **resolution** or **storage size** before uploading to the application server to save bandwidth.
+- **Multi-thread** (web worker) non-blocking compression is supported through options.
 
 
 ## Upgrade to version 2
@@ -89,9 +89,9 @@ yarn add browser-image-compression
 ```javascript
 import imageCompression from 'browser-image-compression';
 ```
-(can be used in framework like React, Angular, Vue etc)
+(can be used in frameworks like React, Angular, Vue etc)
 
-(work with bundler like webpack and rollup)
+(work with bundlers like webpack and rollup)
 
 ### (or) Load UMD js file:
 You can download imageCompression from the [dist folder][dist].
@@ -103,7 +103,7 @@ Alternatively, you can use a CDN like [delivrjs]:
 
 
 ## Support
-If this project help you reduce time to develop, you can buy me a cup of coffee :)
+If this project helps you reduce the time to develop, you can buy me a cup of coffee :)
 
 <a href="https://donaldcwl.github.io/donation/" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-red.png" alt="Buy Me A Coffee" height=60 width=217 ></a>
 
@@ -185,7 +185,7 @@ imageCompression.getExifOrientation(file: File): Promise<number> // based on htt
 | IE10, IE11, Edge| last 2 versions| last 2 versions| last 2 versions| last 2 versions| last 2 versions
 
 ### IE support
-This library uses ES feature such as Promise API, globalThis. If you need to support browser that do not support new ES feature like IE. You can include the core-js polyfill in your project.
+This library uses ES features such as Promise API, globalThis. If you need to support browsers that do not support new ES features like IE. You can include the core-js polyfill in your project.
 
 You can include the following script to load the core-js polyfill:
 ```html
@@ -194,7 +194,7 @@ You can include the following script to load the core-js polyfill:
 
 
 ## Remarks for compression to work in Web Worker
-The browser need to support "OffscreenCanvas" API in order to take advantage of non-blocking compression. If browser do not support "OffscreenCanvas" API, main thread is used instead. See https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas#browser_compatibility for browser compatibility of "OffscreenCanvas" API.
+The browser needs to support "OffscreenCanvas" API in order to take advantage of non-blocking compression. If the browser does not support "OffscreenCanvas" API, the main thread is used instead. See https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas#browser_compatibility for browser compatibility of "OffscreenCanvas" API.
 
 
 ## Typescript type definitions

--- a/example-express-server/README.md
+++ b/example-express-server/README.md
@@ -15,7 +15,7 @@ yarn dev
 ## Sample frontend HTML
 ```html
 <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/browser-image-compression@1.0.17/dist/browser-image-compression.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/browser-image-compression@2.0.0/dist/browser-image-compression.js"></script>
 <input type="file" accept="image/*" onchange="compressImage(event);">
 <script>
     function compressImage (event) {

--- a/example/basic.html
+++ b/example/basic.html
@@ -5,7 +5,16 @@
   <div>
     <span class="animation"></span>
   </div>
-  browser-image-compression@<span id="version">#.#.#</span>
+  browser-image-compression@<span id="version">loading...</span>
+  <select onchange="changeVersion(event)">
+    <option value="2.0.0">2.0.0</option>
+    <option value="1.0.17">1.0.17</option>
+    <option value="1.0.16">1.0.16</option>
+    <option value="1.0.15">1.0.15</option>
+    <option value="1.0.14">1.0.14</option>
+    <option value="1.0.13">1.0.13</option>
+    <option value="1.0.12">1.0.12</option>
+  </select>
   <p>look at console to see logs</p>
   Options:<br />
   <label for="maxSizeMB">maxSizeMB:
@@ -89,8 +98,18 @@
     integrity="sha512-U2gvuX8NaNSc0MOOvd1CTMp/kuzhlJ8HJKWF4G8JAw66iH+1keU5Mrzzrnqktf1SphOCow6dy69sTdblJdI8mA=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script type="text/javascript"
-    src="https://cdn.jsdelivr.net/npm/browser-image-compression@2.0.0/dist/browser-image-compression.js"></script>
+    src="https://cdn.jsdelivr.net/npm/browser-image-compression@latest/dist/browser-image-compression.js"></script>
   <script>
+    function changeVersion(event) {
+      document.querySelector("#version").innerHTML = 'loading...';
+      const script = document.createElement('script');
+      script.src = "https://cdn.jsdelivr.net/npm/browser-image-compression@"+event.srcElement.value+"/dist/browser-image-compression.js";
+      document.body.appendChild(script);
+      script.addEventListener('load', () => {
+        document.querySelector("#version").innerHTML = imageCompression.version;
+      });
+    }
+
     var controller
     document.querySelector("#version").innerHTML = imageCompression.version;
     function compressImage(event, useWebWorker) {

--- a/example/basic.html
+++ b/example/basic.html
@@ -1,113 +1,171 @@
 <!DOCTYPE html>
 <html>
+
 <body>
-browser-image-compression@<span id="version">#.#.#</span>
-<p>look at console to see logs</p>
-Options:<br />
-<label for="maxSizeMB">maxSizeMB: <input type="number" id="maxSizeMB" name="maxSizeMB" value="1" /></label><br />
-<label for="maxWidthOrHeight">maxWidthOrHeight: <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight"
-                                                       value="1024" /></label>
-<hr>
-<div>
+  <div>
+    <span class="animation"></span>
+  </div>
+  browser-image-compression@<span id="version">#.#.#</span>
+  <p>look at console to see logs</p>
+  Options:<br />
+  <label for="maxSizeMB">maxSizeMB:
+    <input type="number" id="maxSizeMB" name="maxSizeMB" value="1" /></label><br />
+  <label for="maxWidthOrHeight">maxWidthOrHeight:
+    <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight" value="1024" /></label>
+  <hr />
+  <div>
     <label for="web-worker">
-        Compress in web-worker <span id="web-worker-progress"></span>
-        <input id="web-worker" type="file" accept="image/*" onchange="compressImage(event, true);">
+      Compress in web-worker <span id="web-worker-progress"></span>
+      <input id="web-worker" type="file" accept="image/*" onchange="compressImage(event, true);" />
     </label>
     <p id="web-worker-log"></p>
-</div>
-<hr>
-<div>
+  </div>
+  <hr />
+  <div>
     <label for="main-thread">
-        Compress in main thread <span id="main-thread-progress"></span>
-        <input id="main-thread" type="file" accept="image/*" onchange="compressImage(event, false);">
+      Compress in main thread <span id="main-thread-progress"></span>
+      <input id="main-thread" type="file" accept="image/*" onchange="compressImage(event, false);" />
     </label>
     <p id="main-thread-log"></p>
-</div>
-<table>
-    <tr>
+  </div>
+  <div>
+    <button onclick="abort()">Abort</button>
+  </div>
+  <!-- <table>
+      <tr>
         <td>input preview</td>
         <td>output preview</td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><img id="preview" /></td>
         <td><img id="preview-after-compress" /></td>
-    </tr>
-</table>
+      </tr>
+    </table> -->
 
-<style>
-    table, th, td {
-        border: 1px solid black;
-        border-collapse: collapse;
+  <style>
+    .animation {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: rgb(0, 153, 255);
+      animation: left-right 2s ease-in-out infinite;
+    }
+
+    @keyframes left-right {
+      0% {
+        background-color: rgb(0, 153, 255);
+        transform: translateX(0%)
+      }
+
+      50% {
+        background-color: rgb(255, 53, 0);
+        transform: translateX(calc(min(300px, 100vw)))
+      }
+
+      100% {
+        transform: translateX(0%)
+      }
+    }
+
+    table,
+    th,
+    td {
+      border: 1px solid black;
+      border-collapse: collapse;
     }
 
     td {
-        vertical-align: top;
-        width: 50%;
+      vertical-align: top;
+      width: 50%;
     }
 
     img {
-        max-width: 100%;
+      max-width: 100%;
     }
-</style>
+  </style>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/3.21.1/minified.min.js"
+    integrity="sha512-U2gvuX8NaNSc0MOOvd1CTMp/kuzhlJ8HJKWF4G8JAw66iH+1keU5Mrzzrnqktf1SphOCow6dy69sTdblJdI8mA=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script type="text/javascript"
+    src="https://cdn.jsdelivr.net/npm/browser-image-compression@2.0.0/dist/browser-image-compression.js"></script>
+  <script>
+    var controller
+    document.querySelector("#version").innerHTML = imageCompression.version;
+    function compressImage(event, useWebWorker) {
+      var file = event.target.files[0];
+      var logDom, progressDom;
+      if (useWebWorker) {
+        logDom = document.querySelector("#web-worker-log");
+        progressDom = document.querySelector("#web-worker-progress");
+      } else {
+        logDom = document.querySelector("#main-thread-log");
+        progressDom = document.querySelector("#main-thread-progress");
+      }
+      // document.getElementById("preview").src = URL.createObjectURL(file);
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/browser-image-compression@1.0.17/dist/browser-image-compression.js"></script>
-<script>
-  document.querySelector('#version').innerHTML = imageCompression.version
-  function compressImage (event, useWebWorker) {
-    var file = event.target.files[0]
-    var logDom, progressDom
-    if (useWebWorker) {
-      logDom = document.querySelector('#web-worker-log')
-      progressDom = document.querySelector('#web-worker-progress')
-    } else {
-      logDom = document.querySelector('#main-thread-log')
-      progressDom = document.querySelector('#main-thread-progress')
+      logDom.innerHTML =
+        "Source image size:" + (file.size / 1024 / 1024).toFixed(2) + "mb";
+      console.log("input", file);
+      imageCompression.getExifOrientation(file).then(function (o) {
+        console.log("ExifOrientation", o);
+      });
+
+      controller = typeof AbortController !== 'undefined' && new AbortController();
+
+      var options = {
+        maxSizeMB: parseFloat(document.querySelector("#maxSizeMB").value),
+        maxWidthOrHeight: parseFloat(
+          document.querySelector("#maxWidthOrHeight").value
+        ),
+        useWebWorker: useWebWorker,
+        onProgress: onProgress,
+      };
+      if (controller) {
+        options.signal = controller.signal;
+      }
+      imageCompression(file, options)
+        .then(function (output) {
+          logDom.innerHTML +=
+            ", output size:" + (output.size / 1024 / 1024).toFixed(2) + "mb";
+          console.log("output", output);
+          const downloadLink = URL.createObjectURL(output);
+          logDom.innerHTML +=
+            '&nbsp;<a href="' +
+            downloadLink +
+            '" download="' +
+            file.name +
+            '">download compressed image</a>';
+          // document.getElementById('preview-after-compress').src = downloadLink
+          return uploadToServer(output);
+        })
+        .catch(function (error) {
+          alert(error.message);
+        });
+
+      function onProgress(p) {
+        console.log("onProgress", p);
+        progressDom.innerHTML = "(" + p + "%" + ")";
+      }
     }
-    document.getElementById('preview').src = URL.createObjectURL(file)
 
-    logDom.innerHTML = 'Source image size:' + (file.size / 1024 / 1024).toFixed(2) + 'mb'
-    console.log('input', file)
-    imageCompression.getExifOrientation(file).then(function (o) {
-      console.log('ExifOrientation', o)
-    })
-
-    var options = {
-      maxSizeMB: parseFloat(document.querySelector('#maxSizeMB').value),
-      maxWidthOrHeight: parseFloat(document.querySelector('#maxWidthOrHeight').value),
-      useWebWorker: useWebWorker,
-      onProgress: onProgress
+    function abort() {
+      if (!controller) return
+      controller.abort(new Error('I just want to stop'));
     }
-    imageCompression(file, options)
-      .then(function (output) {
-          logDom.innerHTML += ', output size:' + (output.size / 1024 / 1024).toFixed(2) + 'mb'
-          console.log('output', output)
-          const downloadLink = URL.createObjectURL(output)
-          logDom.innerHTML += '&nbsp;<a href="' + downloadLink + '" download="' + file.name + '">download compressed image</a>'
-          document.getElementById('preview-after-compress').src = downloadLink
-          return uploadToServer(output)
-      })
-      .catch(function (error) {
-        alert(error.message)
-      })
 
-
-    function onProgress (p) {
-      progressDom.innerHTML = '(' + p + '%' + ')'
+    function uploadToServer(file) {
+      // const formData = new FormData()
+      // formData.append('image', file, file.name)
+      // const url = 'http://localhost:3000/image-upload-api'
+      // return fetch(url, {
+      //   method: 'POST',
+      //   body: formData
+      // }).then(res => res.json())
+      //   .then(body => console.log('got server response', body))
     }
-  }
-
-  function uploadToServer (file) {
-    // const formData = new FormData()
-    // formData.append('image', file, file.name)
-    // const url = 'http://localhost:3000/image-upload-api'
-    // console.log('calling api', url, 'with data', Array.from(formData.entries())[0])
-    // return fetch(url, {
-    //   method: 'POST',
-    //   body: formData
-    // }).then(res => res.json())
-    //   .then(body => console.log('got server response', body))
-  }
-</script>
+  </script>
 </body>
+
 </html>

--- a/example/development.html
+++ b/example/development.html
@@ -1,113 +1,171 @@
 <!DOCTYPE html>
 <html>
+
 <body>
-browser-image-compression@<span id="version">#.#.#</span>
-<p>look at console to see logs</p>
-Options:<br />
-<label for="maxSizeMB">maxSizeMB: <input type="number" id="maxSizeMB" name="maxSizeMB" value="1" /></label><br />
-<label for="maxWidthOrHeight">maxWidthOrHeight: <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight"
-                                                       value="1024" /></label>
-<hr>
-<div>
+  <div>
+    <span class="animation"></span>
+  </div>
+  browser-image-compression@<span id="version">#.#.#</span>
+  <p>look at console to see logs</p>
+  Options:<br />
+  <label for="maxSizeMB">maxSizeMB:
+    <input type="number" id="maxSizeMB" name="maxSizeMB" value="1" /></label><br />
+  <label for="maxWidthOrHeight">maxWidthOrHeight:
+    <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight" value="1024" /></label>
+  <hr />
+  <div>
     <label for="web-worker">
-        Compress in web-worker <span id="web-worker-progress"></span>
-        <input id="web-worker" type="file" accept="image/*" onchange="compressImage(event, true);">
+      Compress in web-worker <span id="web-worker-progress"></span>
+      <input id="web-worker" type="file" accept="image/*" onchange="compressImage(event, true);" />
     </label>
     <p id="web-worker-log"></p>
-</div>
-<hr>
-<div>
+  </div>
+  <hr />
+  <div>
     <label for="main-thread">
-        Compress in main thread <span id="main-thread-progress"></span>
-        <input id="main-thread" type="file" accept="image/*" onchange="compressImage(event, false);">
+      Compress in main thread <span id="main-thread-progress"></span>
+      <input id="main-thread" type="file" accept="image/*" onchange="compressImage(event, false);" />
     </label>
     <p id="main-thread-log"></p>
-</div>
-<table>
-    <tr>
+  </div>
+  <div>
+    <button onclick="abort()">Abort</button>
+  </div>
+  <!-- <table>
+      <tr>
         <td>input preview</td>
         <td>output preview</td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><img id="preview" /></td>
         <td><img id="preview-after-compress" /></td>
-    </tr>
-</table>
+      </tr>
+    </table> -->
 
-<style>
-    table, th, td {
-        border: 1px solid black;
-        border-collapse: collapse;
+  <style>
+    .animation {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: rgb(0, 153, 255);
+      animation: left-right 2s ease-in-out infinite;
+    }
+
+    @keyframes left-right {
+      0% {
+        background-color: rgb(0, 153, 255);
+        transform: translateX(0%);
+      }
+
+      50% {
+        background-color: rgb(255, 53, 0);
+        transform: translateX(300px);
+        transform: translateX(calc(min(300px, 100vw)));
+      }
+
+      100% {
+        transform: translateX(0%);
+      }
+    }
+
+    table,
+    th,
+    td {
+      border: 1px solid black;
+      border-collapse: collapse;
     }
 
     td {
-        vertical-align: top;
-        width: 50%;
+      vertical-align: top;
+      width: 50%;
     }
 
     img {
-        max-width: 100%;
+      max-width: 100%;
     }
-</style>
+  </style>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/3.21.1/minified.min.js"
+    integrity="sha512-U2gvuX8NaNSc0MOOvd1CTMp/kuzhlJ8HJKWF4G8JAw66iH+1keU5Mrzzrnqktf1SphOCow6dy69sTdblJdI8mA=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script type="text/javascript" src="../dist/browser-image-compression.js"></script>
+  <script>
+    var controller
+    document.querySelector("#version").innerHTML = imageCompression.version;
+    function compressImage(event, useWebWorker) {
+      var file = event.target.files[0];
+      var logDom, progressDom;
+      if (useWebWorker) {
+        logDom = document.querySelector("#web-worker-log");
+        progressDom = document.querySelector("#web-worker-progress");
+      } else {
+        logDom = document.querySelector("#main-thread-log");
+        progressDom = document.querySelector("#main-thread-progress");
+      }
+      // document.getElementById("preview").src = URL.createObjectURL(file);
 
-<script type="text/javascript" src="../dist/browser-image-compression.js"></script>
-<script>
-  document.querySelector('#version').innerHTML = imageCompression.version
-  function compressImage (event, useWebWorker) {
-    var file = event.target.files[0]
-    var logDom, progressDom
-    if (useWebWorker) {
-      logDom = document.querySelector('#web-worker-log')
-      progressDom = document.querySelector('#web-worker-progress')
-    } else {
-      logDom = document.querySelector('#main-thread-log')
-      progressDom = document.querySelector('#main-thread-progress')
+      logDom.innerHTML =
+        "Source image size:" + (file.size / 1024 / 1024).toFixed(2) + "mb";
+      console.log("input", file);
+      imageCompression.getExifOrientation(file).then(function (o) {
+        console.log("ExifOrientation", o);
+      });
+
+      controller = typeof AbortController !== 'undefined' && new AbortController();
+
+      var options = {
+        maxSizeMB: parseFloat(document.querySelector("#maxSizeMB").value),
+        maxWidthOrHeight: parseFloat(
+          document.querySelector("#maxWidthOrHeight").value
+        ),
+        useWebWorker: useWebWorker,
+        onProgress: onProgress,
+      };
+      if (controller) {
+        options.signal = controller.signal;
+      }
+      imageCompression(file, options)
+        .then(function (output) {
+          logDom.innerHTML +=
+            ", output size:" + (output.size / 1024 / 1024).toFixed(2) + "mb";
+          console.log("output", output);
+          const downloadLink = URL.createObjectURL(output);
+          logDom.innerHTML +=
+            '&nbsp;<a href="' +
+            downloadLink +
+            '" download="' +
+            file.name +
+            '">download compressed image</a>';
+          // document.getElementById('preview-after-compress').src = downloadLink
+          return uploadToServer(output);
+        })
+        .catch(function (error) {
+          alert(error.message);
+        });
+
+      function onProgress(p) {
+        console.log("onProgress", p);
+        progressDom.innerHTML = "(" + p + "%" + ")";
+      }
     }
-    document.getElementById('preview').src = URL.createObjectURL(file)
 
-    logDom.innerHTML = 'Source image size:' + (file.size / 1024 / 1024).toFixed(2) + 'mb'
-    console.log('input', file)
-    imageCompression.getExifOrientation(file).then(function (o) {
-      console.log('ExifOrientation', o)
-    })
-
-    var options = {
-      maxSizeMB: parseFloat(document.querySelector('#maxSizeMB').value),
-      maxWidthOrHeight: parseFloat(document.querySelector('#maxWidthOrHeight').value),
-      useWebWorker: useWebWorker,
-      onProgress: onProgress
+    function abort() {
+      if (!controller) return
+      controller.abort(new Error('I just want to stop'));
     }
-    imageCompression(file, options)
-      .then(function (output) {
-        logDom.innerHTML += ', output size:' + (output.size / 1024 / 1024).toFixed(2) + 'mb'
-        console.log('output', output)
-        const downloadLink = URL.createObjectURL(output)
-        logDom.innerHTML += '&nbsp;<a href="' + downloadLink + '" download="' + file.name + '">download compressed image</a>'
-        document.getElementById('preview-after-compress').src = downloadLink
-        return uploadToServer(output)
-      })
-      .catch(function (error) {
-        alert(error.message)
-      })
-      
-    function onProgress (p) {
-      console.log('onProgress', p)
-      progressDom.innerHTML = '(' + p + '%' + ')'
-    }
-  }
 
-  function uploadToServer (file) {
-    // const formData = new FormData()
-    // formData.append('image', file, file.name)
-    // const url = 'http://localhost:3000/image-upload-api'
-    // console.log('calling api', url, 'with data', Array.from(formData.entries())[0])
-    // return fetch(url, {
-    //   method: 'POST',
-    //   body: formData
-    // }).then(res => res.json())
-    //   .then(body => console.log('got server response', body))
-  }
-</script>
+    function uploadToServer(file) {
+      // const formData = new FormData()
+      // formData.append('image', file, file.name)
+      // const url = 'http://localhost:3000/image-upload-api'
+      // return fetch(url, {
+      //   method: 'POST',
+      //   body: formData
+      // }).then(res => res.json())
+      //   .then(body => console.log('got server response', body))
+    }
+  </script>
 </body>
+
 </html>

--- a/lib/image-compression.js
+++ b/lib/image-compression.js
@@ -22,6 +22,7 @@ import {
  * @param {Function} [options.onProgress] - a function takes one progress argument (progress from 0 to 100)
  * @param {string} [options.fileType] - default to be the original mime type from the image file
  * @param {number} [options.initialQuality=1.0]
+ * @param {boolean} [options.alwaysKeepResolution=false]
  * @param {number} previousProgress - for internal try catch rerunning start from previous progress
  * @returns {Promise<File | Blob>}
  */
@@ -88,15 +89,17 @@ export default async function compress(file, options, previousProgress = 0) {
   const renderedSize = tempFile.size;
   let currentSize = renderedSize;
   let compressedFile;
-  let newCanvas; let
-    ctx;
+  let newCanvas;
+  let ctx;
   let canvas = orientationFixedCanvas;
+  const shouldReduceResolution = !options.alwaysKeepResolution && origExceedMaxSize;
   while (remainingTrials-- && (currentSize > maxSizeByte || currentSize > sourceSize)) {
-    const newWidth = origExceedMaxSize ? canvas.width * 0.95 : canvas.width;
-    const newHeight = origExceedMaxSize ? canvas.height * 0.95 : canvas.height;
+    const newWidth = shouldReduceResolution ? canvas.width * 0.95 : canvas.width;
+    const newHeight = shouldReduceResolution ? canvas.height * 0.95 : canvas.height;
     if (process.env.BUILD === 'development') {
       console.log('current width', newWidth);
       console.log('current height', newHeight);
+      console.log('current quality', quality);
     }
     [newCanvas, ctx] = getNewCanvasAndCtx(newWidth, newHeight);
 

--- a/lib/image-compression.js
+++ b/lib/image-compression.js
@@ -16,7 +16,7 @@ import {
  * @param {Object} options
  * @param {number} [options.maxSizeMB=Number.POSITIVE_INFINITY]
  * @param {number} [options.maxWidthOrHeight=undefined]
- * @param {boolean} [options.useWebWorker=false]
+ * @param {boolean} [options.useWebWorker=true]
  * @param {number} [options.maxIteration=10]
  * @param {number} [options.exifOrientation] - default to be the exif orientation from the image file
  * @param {Function} [options.onProgress] - a function takes one progress argument (progress from 0 to 100)

--- a/lib/image-compression.js
+++ b/lib/image-compression.js
@@ -23,6 +23,7 @@ import {
  * @param {string} [options.fileType] - default to be the original mime type from the image file
  * @param {number} [options.initialQuality=1.0]
  * @param {boolean} [options.alwaysKeepResolution=false]
+ * @param {AbortSignal} [options.signal]
  * @param {number} previousProgress - for internal try catch rerunning start from previous progress
  * @returns {Promise<File | Blob>}
  */
@@ -30,11 +31,17 @@ export default async function compress(file, options, previousProgress = 0) {
   let progress = previousProgress;
 
   function incProgress(inc = 5) {
+    if (options.signal && options.signal.aborted) {
+      throw options.signal.reason;
+    }
     progress += inc;
     options.onProgress(Math.min(progress, 100));
   }
 
   function setProgress(p) {
+    if (options.signal && options.signal.aborted) {
+      throw options.signal.reason;
+    }
     progress = Math.min(Math.max(p, progress), 100);
     options.onProgress(progress);
   }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,6 +19,8 @@ interface Options {
     fileType?: string;
     /** @default 1.0 */
     initialQuality?: number;
+    /** @default false */
+    alwaysKeepResolution?: boolean;
 }
 
 declare function imageCompression(image: File, options: Options): Promise<File>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,14 +1,13 @@
-// Type definitions for browser-image-compression 1.0
+// Type definitions for browser-image-compression 2.0
 // Project: https://github.com/Donaldcwl/browser-image-compression
 // Definitions by: Donald <https://github.com/Donaldcwl> & Jamie Haywood <https://github.com/jamiehaywood>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Options {
     /** @default Number.POSITIVE_INFINITY */
     maxSizeMB?: number;
     /** @default undefined */
     maxWidthOrHeight?: number;
-    /** @default false */
+    /** @default true */
     useWebWorker?: boolean;
     /** @default 10 */
     maxIteration?: number;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -21,6 +21,8 @@ interface Options {
     initialQuality?: number;
     /** @default false */
     alwaysKeepResolution?: boolean;
+    /** @default undefined */
+    signal?: AbortSignal;
 }
 
 declare function imageCompression(image: File, options: Options): Promise<File>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,3 @@
-import './polyfill';
-
 import compress from './image-compression';
 import {
   canvasToFile,

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ import compressOnWebWorker from './web-worker';
  * @param {string} [options.fileType] - default to be the original mime type from the image file
  * @param {number} [options.initialQuality=1.0]
  * @param {boolean} [options.alwaysKeepResolution=false]
+ * @param {AbortSignal} [options.signal]
  * @returns {Promise<File | Blob>}
  */
 async function imageCompression(file, options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,10 +22,10 @@ import compressOnWebWorker from './web-worker';
  * Compress an image file.
  *
  * @param {File} file
- * @param {Object} opts - { maxSizeMB=Number.POSITIVE_INFINITY, maxWidthOrHeight, useWebWorker=false, maxIteration = 10, exifOrientation, fileType }
+ * @param {Object} options - { maxSizeMB=Number.POSITIVE_INFINITY, maxWidthOrHeight, useWebWorker=false, maxIteration = 10, exifOrientation, fileType }
  * @param {number} [options.maxSizeMB=Number.POSITIVE_INFINITY]
  * @param {number} [options.maxWidthOrHeight=undefined]
- * @param {boolean} [options.useWebWorker=false]
+ * @param {boolean} [options.useWebWorker=true]
  * @param {number} [options.maxIteration=10]
  * @param {number} [options.exifOrientation] - default to be the exif orientation from the image file
  * @param {Function} [options.onProgress] - a function takes one progress argument (progress from 0 to 100)

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,8 @@ import compressOnWebWorker from './web-worker';
  * @param {number} [options.exifOrientation] - default to be the exif orientation from the image file
  * @param {Function} [options.onProgress] - a function takes one progress argument (progress from 0 to 100)
  * @param {string} [options.fileType] - default to be the original mime type from the image file
+ * @param {number} [options.initialQuality=1.0]
+ * @param {boolean} [options.alwaysKeepResolution=false]
  * @returns {Promise<File | Blob>}
  */
 async function imageCompression(file, options) {

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,2 +1,0 @@
-import 'core-js/es/global-this';
-import 'core-js/es/object/assign';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -207,7 +207,7 @@ export function isIOS() {
     'iPod',
   ].includes(navigator.platform)
   // iPad on iOS 13 detection
-  || (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
+  || (navigator.userAgent.includes('Mac') && typeof document !== 'undefined' && 'ontouchend' in document);
   return isIOS.cachedResult;
 }
 

--- a/lib/web-worker.js
+++ b/lib/web-worker.js
@@ -358,6 +358,9 @@ export default function compressOnWebWorker(file, options) {
 
     function handler(e) {
       if (e.data.id === id) {
+        if (options.signal && options.signal.aborted) {
+          return;
+        }
         if (e.data.progress !== undefined) {
           options.onProgress(e.data.progress);
           return;
@@ -372,12 +375,18 @@ export default function compressOnWebWorker(file, options) {
 
     worker.addEventListener('message', handler);
     worker.addEventListener('error', reject);
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => {
+        worker.terminate();
+        reject(options.signal.reason);
+      });
+    }
 
     worker.postMessage({
       file,
       id,
       imageCompressionLibUrl,
-      options: { ...options, onProgress: undefined },
+      options: { ...options, onProgress: undefined, signal: undefined },
     });
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-image-compression",
-  "version": "1.0.17",
+  "version": "2.0.0",
   "description": "Compress images in the browser",
   "main": "dist/browser-image-compression.js",
   "module": "dist/browser-image-compression.mjs",
@@ -39,7 +39,6 @@
     "dist"
   ],
   "dependencies": {
-    "core-js": "^3.16.1",
     "uzip": "0.20201231.0"
   },
   "devDependencies": {
@@ -69,7 +68,8 @@
     "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-license": "^2.0.0",
     "rollup-plugin-nodent": "^0.2.2",
-    "rollup-plugin-terser": "^5.0.0"
+    "rollup-plugin-terser": "^5.0.0",
+    "rollup-plugin-visualizer": "^5.6.0"
   },
   "config": {
     "commitizen": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 import path from 'path';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 const pkg = require('./package.json');
 
@@ -51,6 +52,11 @@ const plugins = [
         rename: path.basename(pkg.types),
       },
     ],
+  }),
+  visualizer({
+    open: false,
+    gzipSize: true,
+    brotliSize: true,
   }),
 ];
 

--- a/test/setup_global.js
+++ b/test/setup_global.js
@@ -1,6 +1,8 @@
 const pkg = require('../package.json');
 
 global.process.env.NODE_ENV = 'test';
-global.process.env.BUILD = 'test';
+global.process.env.BUILD = 'development';
+global.console.log = () => {};
+global.console.error = () => {};
 global.__buildDate__ = () => JSON.stringify(new Date());
 global.__buildVersion__ = JSON.stringify(pkg.version);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,11 +1505,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001259:
-  version "1.0.30001260"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz#e3be3f34ddad735ca4a2736fa9e768ef34316270"
-  integrity sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==
-  dependencies:
-    nanocolors "^0.1.0"
+  version "1.0.30001327"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001327.tgz"
+  integrity sha512-1/Cg4jlD9qjZzhbzkzEaAC2JHsP0WrOc8Rd/3a3LuajGzGWR/hD7TVyvq99VqmTy99eVh8Zkmdq213OgvgXx7w==
 
 canvas@2.6.1:
   version "2.6.1"
@@ -1751,11 +1749,6 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.16.1:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.18.0.tgz#9af3f4a6df9ba3428a3fb1b171f1503b3f40cc49"
-  integrity sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w==
-
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1925,6 +1918,11 @@ default-require-extensions@^3.0.0:
   integrity sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==
   dependencies:
     strip-bom "^4.0.0"
+
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
 define-properties@^1.1.3:
   version "1.1.3"
@@ -2951,6 +2949,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3072,6 +3075,13 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -3619,7 +3629,7 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
-nanocolors@^0.1.0, nanocolors@^0.1.5:
+nanocolors@^0.1.5:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.12.tgz#8577482c58cbd7b5bb1681db4cf48f11a87fd5f6"
   integrity sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==
@@ -3628,6 +3638,11 @@ nanoid@3.1.25:
   version "3.1.25"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
+
+nanoid@^3.1.32:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
+  integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3861,6 +3876,15 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -4451,6 +4475,16 @@ rollup-plugin-terser@^5.0.0:
     serialize-javascript "^4.0.0"
     terser "^4.6.2"
 
+rollup-plugin-visualizer@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.6.0.tgz#06aa7cf3fd504a29d404335700f2a3f28ebb33f3"
+  integrity sha512-CKcc8GTUZjC+LsMytU8ocRr/cGZIfMR7+mdy4YnlyetlmIl/dM8BMnOEpD4JPIGt+ZVW7Db9ZtSsbgyeBH3uTA==
+  dependencies:
+    nanoid "^3.1.32"
+    open "^8.4.0"
+    source-map "^0.7.3"
+    yargs "^17.3.1"
+
 rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
@@ -4631,6 +4665,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 source-map@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
@@ -4753,7 +4792,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5309,6 +5348,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
+yargs-parser@^21.0.0:
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
+
 yargs-unparser@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
@@ -5348,6 +5392,19 @@ yargs@^15.0.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.3.1:
+  version "17.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.4.1.tgz#ebe23284207bb75cee7c408c33e722bfb27b5284"
+  integrity sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
* feature: example html - added CSS animation for showing main thread status
* feature: example html - added version switch
* feature: support AbortController (abort / cancel during compression) [#101](https://github.com/Donaldcwl/browser-image-compression/issues/101)
* feature: options.alwaysKeepResolution (default: false) - keep the resolution (width and height) during compression and reduce the quality only (note that options.maxWidthOrHeight is still applied if set) [#127](https://github.com/Donaldcwl/browser-image-compression/issues/127)
* fixed: Main thread is blocked on Mac device for options.useWebWorker=true [#139](https://github.com/Donaldcwl/browser-image-compression/issues/139)
* updated: dropped core-js to reduce bundle size [#138](https://github.com/Donaldcwl/browser-image-compression/issues/138)
* updated: options.useWebWorker default set to true