### PR TITLE
[bug fix] Clear unused canvases to avoid memory leak. 

### DIFF
--- a/lib/image-compression.js
+++ b/lib/image-compression.js
@@ -89,6 +89,9 @@ export default async function compress(file, options, previousProgress = 0) {
     if (process.env.BUILD === 'development') {
       console.log('no need to compress');
     }
+    cleanupCanvasMemory(maxWidthOrHeightFixedCanvas);
+    cleanupCanvasMemory(orientationFixedCanvas);
+    cleanupCanvasMemory(origCanvas);
     setProgress(100);
     return tempFile;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -315,8 +315,8 @@ export async function isAutoOrientationInBrowser() {
   const testImageCanvas = (await drawFileInCanvas(testImageFile))[1];
   const testImageFile2 = await canvasToFile(testImageCanvas, testImageFile.type, testImageFile.name, testImageFile.lastModified);
   cleanupCanvasMemory(testImageCanvas);
-  const img = (await drawFileInCanvas(testImageFile2))[0];
-  // console.log('img', img.width, img.height)
+  const [img, fileCanvas] = (await drawFileInCanvas(testImageFile2));
+  cleanupCanvasMemory(fileCanvas);
 
   isAutoOrientationInBrowser.cachedResult = img.width === 1 && img.height === 2;
   return isAutoOrientationInBrowser.cachedResult;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -292,9 +292,11 @@ export function cleanupCanvasMemory(canvas) {
   // garbage clean canvas for safari
   // ref: https://bugs.webkit.org/show_bug.cgi?id=195325
   // eslint-disable-next-line no-param-reassign
-  canvas.width = 0;
+  canvas.width = 1;
   // eslint-disable-next-line no-param-reassign
-  canvas.height = 0;
+  canvas.height = 1;
+  const ctx = canvas.getContext('2d');
+  ctx && ctx.clearRect(0, 0, 1, 1);
 }
 
 // Check if browser supports automatic image orientation


### PR DESCRIPTION
This resolved the issue where some canvases were not cleared properly, and it might result in reaching the limit of maximum canvas memory usage when the client attempted to compress multiple images.