### PR TITLE
fix: reject Promises with Error objects

### DIFF
--- a/lib/copyExifWithoutOrientation.js
+++ b/lib/copyExifWithoutOrientation.js
@@ -21,7 +21,7 @@ const getApp1Segment = (blob) => new Promise((resolve, reject) => {
   reader.addEventListener('load', ({ target: { result: buffer } }) => {
     const view = new DataView(buffer);
     let offset = 0;
-    if (view.getUint16(offset) !== SOI) return reject('not a valid JPEG');
+    if (view.getUint16(offset) !== SOI) return reject(new Error('not a valid JPEG'));
     offset += 2;
 
     while (true) {
@@ -40,9 +40,9 @@ const getApp1Segment = (blob) => new Promise((resolve, reject) => {
             littleEndian = false;
             break;
           default:
-            return reject('TIFF header contains invalid endian');
+            return reject(new Error('TIFF header contains invalid endian'));
         }
-        if (view.getUint16(tiffOffset + 2, littleEndian) !== 0x2a) { return reject('TIFF header contains invalid version'); }
+        if (view.getUint16(tiffOffset + 2, littleEndian) !== 0x2a) { return reject(new Error('TIFF header contains invalid version')); }
 
         const ifd0Offset = view.getUint32(tiffOffset + 4, littleEndian);
         const endOfTagsOffset = tiffOffset
@@ -56,9 +56,9 @@ const getApp1Segment = (blob) => new Promise((resolve, reject) => {
         ) {
           const tagId = view.getUint16(i, littleEndian);
           if (tagId == TAG_ID_ORIENTATION) {
-            if (view.getUint16(i + 2, littleEndian) !== TAG_TYPE_SHORT) { return reject('Orientation data type is invalid'); }
+            if (view.getUint16(i + 2, littleEndian) !== TAG_TYPE_SHORT) { return reject(new Error('Orientation data type is invalid')); }
 
-            if (view.getUint32(i + 4, littleEndian) !== 1) { return reject('Orientation data count is invalid'); }
+            if (view.getUint32(i + 4, littleEndian) !== 1) { return reject(new Error('Orientation data count is invalid')); }
 
             view.setUint16(i + 8, 1, littleEndian);
             break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,7 +59,7 @@ export function getDataUrlFromFile(file) {
   return new Promise((resolve, reject) => {
     const reader = new CustomFileReader();
     reader.onload = () => resolve(reader.result);
-    reader.onerror = (e) => reject(e);
+    reader.onerror = (event) => reject(new Error(`Error in getDataUrlFromFile: ${event.toString()}`));
     reader.readAsDataURL(file);
   });
 }
@@ -74,7 +74,7 @@ export function loadImage(src) {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => resolve(img);
-    img.onerror = (e) => reject(e);
+    img.onerror = (event) => reject(new Error(`Error in loadImage: ${event.toString()}`));
     img.src = src;
   });
 }
@@ -366,7 +366,7 @@ export function getExifOrientation(file) {
       }
       return resolve(-1); // not defined
     };
-    reader.onerror = (e) => reject(e);
+    reader.onerror = (event) => reject(new Error(`Error in getExifOrientation: ${event.toString()}`));
     reader.readAsArrayBuffer(file);
   });
 }

--- a/lib/web-worker.js
+++ b/lib/web-worker.js
@@ -56,10 +56,10 @@ export default function compressOnWebWorker(file, options) {
     }
 
     worker.addEventListener('message', handler);
-    worker.addEventListener('error', reject);
+    worker.addEventListener('error', (event) => reject(new Error(`Error in WebWorker: ${event.toString()}`)));
     if (options.signal) {
       options.signal.addEventListener('abort', () => {
-        reject(options.signal.reason);
+        reject(new Error(options.signal.reason));
         worker.terminate();
       });
     }


### PR DESCRIPTION
Addresses #211.

Certain browsers (I've observed it in DuckDuckGo Mobile 5) will throw an error if a Promise is rejected with a non-Error object. HTMLElements call `onerror` [with an Event subclass argument](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event), not an error object, so this is causing some noise and losing context for debugging.