### PR TITLE
faster image compression when alwaysKeepResolution is set to true

### DIFF
--- a/example/basic.html
+++ b/example/basic.html
@@ -20,9 +20,9 @@
   <p>look at console to see logs</p>
   Options:<br />
   <label for="maxSizeMB">maxSizeMB:
-    <input type="number" id="maxSizeMB" name="maxSizeMB" value="1" /></label><br />
+    <input type="number" id="maxSizeMB" name="maxSizeMB" value="0.5" /></label><br />
   <label for="maxWidthOrHeight">maxWidthOrHeight:
-    <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight" value="1024" /></label>
+    <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight" value="1200" /></label>
   <hr />
   <div>
     <label for="web-worker">
@@ -142,10 +142,12 @@
         maxWidthOrHeight: parseFloat(
           document.querySelector("#maxWidthOrHeight").value
         ),
-        useWebWorker: useWebWorker,
         onProgress: onProgress,
         preserveExif: true,
-        libURL: "https://cdn.jsdelivr.net/npm/browser-image-compression@"+selectedVersion+"/dist/browser-image-compression.js"
+        libURL: "https://cdn.jsdelivr.net/npm/browser-image-compression@"+selectedVersion+"/dist/browser-image-compression.js",
+        alwaysKeepResolution: true,
+        maxIteration: 100,
+        useWebWorker: false,
       };
       if (controller) {
         options.signal = controller.signal;

--- a/example/development.html
+++ b/example/development.html
@@ -9,9 +9,9 @@
   <p>look at console to see logs</p>
   Options:<br />
   <label for="maxSizeMB">maxSizeMB:
-    <input type="number" id="maxSizeMB" name="maxSizeMB" value="1" /></label><br />
+    <input type="number" id="maxSizeMB" name="maxSizeMB" value="0.5" /></label><br />
   <label for="maxWidthOrHeight">maxWidthOrHeight:
-    <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight" value="1024" /></label>
+    <input type="number" id="maxWidthOrHeight" name="maxWidthOrHeight" value="1200" /></label>
   <hr />
   <div>
     <label for="web-worker">
@@ -119,10 +119,12 @@
         maxWidthOrHeight: parseFloat(
           document.querySelector("#maxWidthOrHeight").value
         ),
-        useWebWorker: useWebWorker,
         onProgress: onProgress,
         preserveExif: true,
-        libURL: location.origin + '/dist/browser-image-compression.js'
+        libURL: location.origin + '/dist/browser-image-compression.js',
+        alwaysKeepResolution: true,
+        maxIteration: 100,
+        useWebWorker: false,
       };
       if (controller) {
         options.signal = controller.signal;

--- a/lib/image-compression.js
+++ b/lib/image-compression.js
@@ -93,7 +93,6 @@ export default async function compress(file, options, previousProgress = 0) {
     return tempFile;
   }
 
-  const sourceSize = file.size;
   const renderedSize = tempFile.size;
   let currentSize = renderedSize;
   let compressedFile;
@@ -101,34 +100,96 @@ export default async function compress(file, options, previousProgress = 0) {
   let ctx;
   let canvas = orientationFixedCanvas;
   const shouldReduceResolution = !options.alwaysKeepResolution && origExceedMaxSize;
-  while (remainingTrials-- && (currentSize > maxSizeByte || currentSize > sourceSize)) {
+
+  //Compressed Image using Binary Search
+  let low = 0;
+  let high = 1;
+  const precision = 10000; // 10kb
+  while(low<=high && remainingTrials >=0)
+  {
+    const mid = (low+high)/2;
     const newWidth = shouldReduceResolution ? canvas.width * 0.95 : canvas.width;
     const newHeight = shouldReduceResolution ? canvas.height * 0.95 : canvas.height;
+
     if (process.env.BUILD === 'development') {
       console.log('current width', newWidth);
       console.log('current height', newHeight);
       console.log('current quality', quality);
+
+      console.log("Low:"+low)
+      console.log("Mid:"+mid)
+      console.log("High:"+high)
     }
     [newCanvas, ctx] = getNewCanvasAndCtx(newWidth, newHeight);
 
     ctx.drawImage(canvas, 0, 0, newWidth, newHeight);
 
-    if (outputFileType === 'image/png') {
-      quality *= 0.85;
-    } else {
-      quality *= 0.95;
-    }
+    quality = mid;
+
     // eslint-disable-next-line no-await-in-loop
     compressedFile = await canvasToFile(newCanvas, outputFileType, file.name, file.lastModified, quality);
 
     cleanupCanvasMemory(canvas);
-
     canvas = newCanvas;
-
     currentSize = compressedFile.size;
-    // console.log('currentSize', currentSize)
+
+    // Check if the current size is within the maximum size limit and the difference
+    // between the maximum size and current size is less than the precision.
+    if (currentSize <= maxSizeByte && (maxSizeByte - currentSize) < precision) {
+      // If true, exit the loop as the desired condition is met.
+      break;
+    }
+    // Check if the current size is within the maximum size limit and the difference
+    // between the maximum size and current size is greater than the precision.
+    else if (currentSize <= maxSizeByte && (maxSizeByte - currentSize) > precision) {
+      // If true, adjust the lower bound to narrow the search range.
+      low = mid + 0.01;
+    }
+    // If the current size exceeds the maximum size limit.
+    else {
+      // Adjust the upper bound to narrow the search range.
+      high = mid - 0.01;
+    }
+
+
+    if (process.env.BUILD === 'development') {
+      console.log("Compressed image size:" + currentSize)
+      console.log("Iteration step count:" + remainingTrials)
+    }
+
     setProgress(Math.min(99, Math.floor(((renderedSize - currentSize) / (renderedSize - maxSizeByte)) * 100)));
+    remainingTrials--;
   }
+
+//    Previous code
+//    while (remainingTrials-- && (currentSize > maxSizeByte || currentSize > sourceSize)) {
+//     const newWidth = shouldReduceResolution ? canvas.width * 0.95 : canvas.width;
+//     const newHeight = shouldReduceResolution ? canvas.height * 0.95 : canvas.height;
+//     if (process.env.BUILD === 'development') {
+//       console.log('current width', newWidth);
+//       console.log('current height', newHeight);
+//       console.log('current quality', quality);
+//     }
+//     [newCanvas, ctx] = getNewCanvasAndCtx(newWidth, newHeight);
+
+//     ctx.drawImage(canvas, 0, 0, newWidth, newHeight);
+
+//     if (outputFileType === 'image/png') {
+//       quality *= 0.85;
+//     } else {
+//       quality *= 0.95;
+//     }
+//     // eslint-disable-next-line no-await-in-loop
+//     compressedFile = await canvasToFile(newCanvas, outputFileType, file.name, file.lastModified, quality);
+
+//     cleanupCanvasMemory(canvas);
+
+//     canvas = newCanvas;
+
+//     currentSize = compressedFile.size;
+//      console.log('currentSize: ', currentSize/1000000 +' MB')
+//     setProgress(Math.min(99, Math.floor(((renderedSize - currentSize) / (renderedSize - maxSizeByte)) * 100)));
+//  }
 
   cleanupCanvasMemory(canvas);
   cleanupCanvasMemory(newCanvas);


### PR DESCRIPTION
When `alwaysKeepResolution` field is set to `true`, existing code tries to decrease the `quality` linearly. 
- For large images (specially png files), this takes a lot of time and  (see #219 )
- sometimes the compressed file size fails to be lower than `maxSizeMB` (see #176 )


To improve the performance in this special case, we used binary search on `quality` based on the notion
- higher quality leads to larger image
- lower quality leads to smaller image

Our target is
- find the highest `quality` where the compressed image file size is lower than `maxSizeMB` in O(log n) time


Demo improvements:
- added a new checkbox  `alwaysKeepResolution`, that allows to change quality without reducing resolution
- show the time it took to do the compression